### PR TITLE
Use browser detected tabs plugin

### DIFF
--- a/book.json
+++ b/book.json
@@ -25,7 +25,8 @@
         "sidebar-ads",
         "codeblock-label",
         "sectionx-ex",
-        "collapsible-menu"
+        "collapsible-menu",
+        "browser-detected-tabs"
     ],
     "pluginsConfig": {
         "ga": {

--- a/en/README.md
+++ b/en/README.md
@@ -4,6 +4,20 @@
 > This work is licensed under the Creative Commons Attribution-ShareAlike 4.0 International License.
 > To view a copy of this license, visit https://creativecommons.org/licenses/by-sa/4.0/
 
+<button class="osToggle" data-os="Windows">Windows</button>
+<button class="osToggle" data-os="Mac">Mac</button>
+<button class="osToggle" data-os="Linux">Linux</button>
+
+{% osContent "Windows" %}
+Windows stuff
+{% endosContent %}
+{% osContent "Mac" %}
+Mac stuff
+{% endosContent %}
+{% osContent "Linux" %}
+Linux stuff
+{% endosContent %}
+
 ## Welcome
 Welcome to the Django Girls Tutorial! We are happy to see you here. :) In this tutorial, we will take you on a journey under the hood of web technologies, offering you a glimpse of all the bits and pieces that need to come together to make the web work as we know it.
 

--- a/en/README.md
+++ b/en/README.md
@@ -4,20 +4,6 @@
 > This work is licensed under the Creative Commons Attribution-ShareAlike 4.0 International License.
 > To view a copy of this license, visit https://creativecommons.org/licenses/by-sa/4.0/
 
-<button class="osToggle" data-os="Windows">Windows</button>
-<button class="osToggle" data-os="Mac">Mac</button>
-<button class="osToggle" data-os="Linux">Linux</button>
-
-{% osContent "Windows" %}
-Windows stuff
-{% endosContent %}
-{% osContent "Mac" %}
-Mac stuff
-{% endosContent %}
-{% osContent "Linux" %}
-Linux stuff
-{% endosContent %}
-
 ## Welcome
 Welcome to the Django Girls Tutorial! We are happy to see you here. :) In this tutorial, we will take you on a journey under the hood of web technologies, offering you a glimpse of all the bits and pieces that need to come together to make the web work as we know it.
 

--- a/en/intro_to_command_line/open_instructions.md
+++ b/en/intro_to_command_line/open_instructions.md
@@ -1,4 +1,8 @@
-<!--sec data-title="Opening: Windows" data-id="windows_prompt" data-collapse=true ces-->
+<button class="osToggle" data-os="Windows">Windows</button>
+<button class="osToggle" data-os="Mac">Mac</button>
+<button class="osToggle" data-os="Linux">Linux</button>
+
+{% osContent "Windows" %}
 
 Depending on your version of Windows and your keyboard, one of the following should open a command window (you may have to experiment a bit, but you don't have to try all of these suggestions):
 - Go to the Start menu or screen, and enter "Command Prompt" in the search field.
@@ -12,16 +16,15 @@ Depending on your version of Windows and your keyboard, one of the following sho
 
 Later in this tutorial, you will need to have two command windows open at the same time. However, on some versions of Windows, if you already have one command window open and you try to open a second one using the same method, it will instead point you to the command window you already have open. Try it now on your computer and see what happens! If you only get one command window, try one of the other methods in the list above. At least one of them should result in a new command window being opened.
 
-<!--endsec-->
+{% endosContent %}
 
-<!--sec data-title="Opening: OS X" data-id="OSX_prompt" data-collapse=true ces-->
+{% osContent "Mac" %}
 
 Go to Applications → Utilities → Terminal.
 
-<!--endsec-->
-
-<!--sec data-title="Opening: Linux" data-id="linux_prompt" data-collapse=true ces-->
+{% endosContent %}
+{% osContent "Linux" %}
 
 It's probably under Applications → Accessories → Terminal, or Applications → System → Terminal, but that may depend on your system. If it's not there, you can try to Google it. :)
 
-<!--endsec-->
+{% endosContent %}

--- a/en/python_installation/instructions.md
+++ b/en/python_installation/instructions.md
@@ -6,7 +6,7 @@ Django is written in Python. We need Python to do anything in Django. Let's star
 
 Please install normal Python as follows, even when you have Anaconda installed on your computer.
 
-<!--sec data-title="Install Python: Windows" data-id="python_windows" data-collapse=true ces-->
+{% osContent "Windows" %}
 
 First check whether your computer is running a 32-bit version or a 64-bit version of Windows, on the "System type" line of the System Info page. To reach this page, try one of these methods:
 * Press the Windows key and Pause/Break key at the same time
@@ -26,10 +26,8 @@ Note: If you are using an older version of Windows (7, Vista, or any older versi
 
 > Django {{ book.django_version }} needs Python {{ book.py_min_version }} or greater, which does not support Windows XP or earlier versions.
 
-<!--endsec-->
-
-<!--sec data-title="Install Python: OS X" data-id="python_OSX"
-data-collapse=true ces-->
+{% endosContent %}
+{% osContent "Mac" %}
 
 > **Note** Before you install Python on OS X, you should ensure your Mac settings allow installing packages that aren't from the App Store. Go to System Preferences (it's in the Applications folder), click "Security & Privacy," and then the "General" tab. If your "Allow apps downloaded from:" is set to "Mac App Store," change it to "Mac App Store and identified developers."
 
@@ -38,11 +36,8 @@ You need to go to the website https://www.python.org/downloads/mac-osx/ and down
 * Download the *Mac OS X 64-bit/32-bit installer* file,
 * Double click *python-{{ book.py_release }}-macosx10.9.pkg* to run the installer.
 
-<!--endsec-->
-
-<!--sec data-title="Install Python: Linux" data-id="python_linux"
-data-collapse=true ces-->
-
+{% endosContent %}
+{% osContent "Linux" %}
 It is very likely that you already have Python installed out of the box. To check if you have it installed (and which version it is), open a console and type the following command:
 
 {% filename %}command-line{% endfilename %}
@@ -60,7 +55,7 @@ $ grep '^NAME=' /etc/os-release
 
 Afterwards, depending on the result, follow one of the following installation guides below this section.
 
-<!--endsec-->
+{% endosContent %}
 
 <!--sec data-title="Install Python: Debian or Ubuntu" data-id="python_debian" data-collapse=true ces-->
 

--- a/en/styles/website.css
+++ b/en/styles/website.css
@@ -62,3 +62,33 @@
         font-size: 16pt;
     }
 }
+
+/* Style for OS buttons */
+button.osToggle {
+    /* Space inside the box */
+    padding: 5px 10px;
+    /* Reduced space between link boxes */
+    margin: 2px 2px 0px;
+    display: inline-block; /* Allow padding and margin */
+    border: 1px solid #ddd; /* Individual link box */
+    text-decoration: none; /* Remove underline from links */
+    color: black; /* Text color */
+    background-color: #f0f0f0; /* Background color */
+    box-shadow: 2px 2px 5px rgba(0, 0, 0, 0.2); /* Drop shadow */
+}
+
+/* Style for the active OS button */
+button.osToggle.active {
+    border-color: #FF9900; /* Highlight color for active button */
+    background-color: #FF9900; /* Background color for active button */
+    color: white; /* Text color for active button */
+    box-shadow: 2px 2px 5px rgba(0, 0, 0, 0.5); /* Stronger drop shadow */
+}
+
+/* Style for divs with data-os-content attribute */
+div[data-os-content] {
+    background-color: #f9f9f9; /* Light grey background */
+    padding: 15px; /* Space inside the div */
+    border: 1px solid #ddd; /* Border around the div */
+    border-radius: 5px; /* Rounded corners */
+}

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "gitbook-plugin-richquotes": "0.0.9",
     "gitbook-plugin-sectionx-ex": "*",
     "gitbook-plugin-sidebar-ads": "^1.0.0",
+    "honkit-plugin-browser-detected-tabs": "^0.0.6",
     "honkit": "^3.4.0"
   },
   "scripts": {},


### PR DESCRIPTION
This PR brings in the [honkit-plugin-browser-detected-tabs](https://github.com/kreeves/honkit-plugin-browser-detected-tabs) library I've created. The library auto detects the OS the user is using and shows them content specific to that OS.

This library adds a new tag that can be used in honkit's markdown to allow us to combine all related OS material
